### PR TITLE
Fix google login

### DIFF
--- a/routes/guests.rb
+++ b/routes/guests.rb
@@ -52,7 +52,7 @@ class Guests < Cuba
           res.redirect "/dashboard"
         # Wrong domain, goes back to members homepage
         else
-          res.redirect "/"
+          render("login_notification", title: "SumOfUs")
         end
       end
 
@@ -60,6 +60,10 @@ class Guests < Cuba
       on google_user.nil? do
         res.redirect "/actionite"
       end
+    end
+
+    on "dashboard" do
+      render("login_notification", title: "SumOfUs")
     end
 
     # Homepage for members (when going to http://192.168.59.103:5000)

--- a/views/login_notification.mote
+++ b/views/login_notification.mote
@@ -1,0 +1,2 @@
+<p>It seems you're not logged in to Google with your SumOfUs account.<br>
+Please, sign in to Google with your SumOfUs account and try to <a href="/actionite">Login again</a>.</p>

--- a/views/login_notification.mote
+++ b/views/login_notification.mote
@@ -1,2 +1,2 @@
 <p>It seems you're not logged in to Google with your SumOfUs account.<br>
-Please, sign in to Google with your SumOfUs account and try to <a href="/actionite">Login again</a>.</p>
+Please, log in to Google with your SumOfUs account and try to <a href="/actionite">log in to Actionite again</a>.</p>


### PR DESCRIPTION
I'm not completely sure about this solution but I think it could work:

- When a campaigner is not logged into Google with any account, when going to `/actionite`, she/he will need to click on the SignIn Google button to log in, choose the correct account and it will redirect to `/dashboard`.

- When a campaigner is signed into her/his SOU Google account, when going to `/actionite` it will login automatically and redirects to `/dashboard`.

- When a campaigner is logged into her/his personal Google account, when going to `/actionite` it will redirect to a notification page that explains what the problem is (not being logged into her/his SOU Google account), and ask to do that in order to try lo login again into Actionite (this will also works if the campaigner is logged into her/his personal Google account and tries to go to `/dashboard`).
